### PR TITLE
clarification readme section middldeware returns value

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Here we defined a component that allows us to check if user is not logged in, th
 
 Now whenever a user hits any of the account routes, the `Guardian` component will be called first, if the user is not logged in then he/she will be redirected to the given route `/login` and called instead of the current page component.
 
-If the middleware returned a value, then it will be displayed instead of the page component.
+If the middleware returns a `truthy` value, it will be displayed instead of the page component. Otherwise, if the middleware returns a `falsy` value (`null`, `false`, `""`, `0`), the page component will be displayed.
 
 So the middleware can look like:
 


### PR DESCRIPTION
I wanted to clarify that when I returned 0 as a number value or Boolean false, the page component is rendered not the falsy values I returned! Otherwise, any returned `truthy` values cut off the middleware cycle and returned these truthy values instead.

it may be a little bit clarification for documentation I think.